### PR TITLE
bugfix: fix query args typing to allow null value

### DIFF
--- a/wp-graphql-wpml.php
+++ b/wp-graphql-wpml.php
@@ -294,7 +294,7 @@ function wpgraphqlwpml__theme_mod_nav_menu_locations(array $args)
     return $args;
 }
 
-function wpgraphqlwpml__filter_graphql_connection_query_args(array $args)
+function wpgraphqlwpml__filter_graphql_connection_query_args(array $args = null)
 {
     global $sitepress;
 


### PR DESCRIPTION
## Description
Function `wpgraphqlwpml__filter_graphql_connection_query_args` throws error on route where nul is passed to the wp-graphql filter `graphql_connection_query_args`

## To reproduce
Query a route route where no query param is returned, e.g.:
```
query FrontPageCssAssets {
  page(id: "/", idType: URI) {
    enqueuedStylesheets {
      nodes {
        src
      }
    }
  }
}
```
With wp-graphql-wpml activated, this route throw the following errror:
`Argument 1 passed to wpgraphqlwpml__filter_graphql_connection_query_args() must be of the type array, null given`

## Fix

Looking at the return value of the filter, it looks like `get_querry_args()` has a return value of mixed:
see  https://github.com/wp-graphql/wp-graphql/blob/e6c7bcac4444c73866d87d67904556df12dd8b2b/src/Data/Connection/AbstractConnectionResolver.php#L310

To keep compatibility with php 7.0, I suggest modifying `(array $args)`  to `(array $args = null)` on`wpgraphqlwpml__filter_graphql_connection_query_args`

If you don't mind bumping compat to php 7.1, `(?array $args )` would also work.


Thank you for your work on this plugin btw, very useful, have a nice day!