### PR TITLE
Enable taxonomy term translations

### DIFF
--- a/wp-graphql-wpml.php
+++ b/wp-graphql-wpml.php
@@ -258,6 +258,7 @@ function wpgraphqlwpml_add_taxonomy_type_fields(\WP_Taxonomy $taxonomy)
                         'id' => Relay::toGlobalId( 'term', (string) $translated_term->term_id ),
                         'locale' => $language['default_locale'],
                         'name' => $translated_term->name,
+                        'slug' => $translated_term->slug,
                     );
                 }
 
@@ -467,6 +468,13 @@ function wpgraphqlwpml_action_graphql_register_types()
                 'type' => 'String',
                 'description' => __(
                     'the name of the translated taxonomy (WPML)',
+                    'wp-graphql-wpml'
+                ),
+            ],
+            'slug' => [
+                'type' => 'String',
+                'description' => __(
+                    'the slug of the translated taxonomy (WPML)',
                     'wp-graphql-wpml'
                 ),
             ],

--- a/wp-graphql-wpml.php
+++ b/wp-graphql-wpml.php
@@ -761,6 +761,18 @@ function wpgraphqlwpml__switch_language_to_all_for_query(array $args)
     return $args;
 }
 
+/**
+ * Remove the `get_term` filter added by WPML during WPGraphQL requests.
+ * This filter forces WPML to adjust term ids *before* other queries are
+ * run. There is a WPML setting named `auto_adjust_ids` that will turn
+ * off this feature, but it should never be on for GraphQL queries.
+ */
+function wpgraphqlwpml__remove_term_adjust_id_filter() {
+    global $sitepress;
+
+    remove_filter('get_term', array($sitepress, 'get_term_adjust_id'), 1);
+}
+
 function wpgraphqlwpml_action_init()
 {
     if (!wpgraphqlwpml_is_graphql_request()) {
@@ -818,9 +830,16 @@ function wpgraphqlwpml_action_init()
         10,
         2
     );
+
+    // Remove the adjust id filter during WPGraphQL requests
+    add_action(
+        'init_graphql_request',
+        'wpgraphqlwpml__remove_term_adjust_id_filter',
+        10,
+        0
+    );
+
 }
 
 
 add_action('graphql_init', 'wpgraphqlwpml_action_init');
-
-

--- a/wp-graphql-wpml.php
+++ b/wp-graphql-wpml.php
@@ -773,6 +773,20 @@ function wpgraphqlwpml__remove_term_adjust_id_filter() {
     remove_filter('get_term', array($sitepress, 'get_term_adjust_id'), 1);
 }
 
+/**
+ * Set the `icl_adjust_id_url_filter_off` global used in the
+ * `WPML_Term_Adjust_Id->filter()` function to indicate if term ids
+ * should be adjusted. Setting this global to `true` ensures that
+ * term ids are not adjusted during GraphQL queries.
+ */
+function wpgraphqlwpml__set_global_adjust_id_filter_off() {
+    // Set global for adjust ids in case the filter is added
+    // again at some point in the request
+    global $icl_adjust_id_url_filter_off;
+
+    $icl_adjust_id_url_filter_off = true;
+}
+
 function wpgraphqlwpml_action_init()
 {
     if (!wpgraphqlwpml_is_graphql_request()) {
@@ -839,6 +853,13 @@ function wpgraphqlwpml_action_init()
         0
     );
 
+    // Set the global adjust id filter to allow for multi-language term queries
+    add_action(
+        'init_graphql_request',
+        'wpgraphqlwpml__set_global_adjust_id_filter_off',
+        10,
+        0
+    );
 }
 
 

--- a/wp-graphql-wpml.php
+++ b/wp-graphql-wpml.php
@@ -299,6 +299,51 @@ function wpgraphqlwpml_action_graphql_register_types()
         ],
     ]);
 
+    register_graphql_object_type('TermTranslation', [
+        'description' => __('Term Translation (WPML)', 'wp-graphql-wpml'),
+        'fields' => [
+            'id' => [
+                'type' => [
+                    'non_null' => 'ID',
+                ],
+                'description' => __(
+                    'the id of the referenced translation (WPML)',
+                    'wp-graphql-wpml'
+                ),
+            ],
+            'databaseId' => [
+                'type' => [
+                    'non_null' => 'Int',
+                ],
+                'description' => __(
+                    'the primary key from the database for the referenced translation (WPML)',
+                    'wp-graphql-wpml'
+                ),
+            ],
+            'href' => [
+                'type' => 'String',
+                'description' => __(
+                    'the relative link to the translated content (WPML)',
+                    'wp-graphql-wpml'
+                ),
+            ],
+            'locale' => [
+                'type' => 'String',
+                'description' => __(
+                    'Language code (WPML)',
+                    'wp-graphql-wpml'
+                ),
+            ],
+            'name' => [
+                'type' => 'String',
+                'description' => __(
+                    'the name of the translated taxonomy (WPML)',
+                    'wp-graphql-wpml'
+                ),
+            ],
+        ],
+    ]);
+
     register_graphql_fields('RootQueryToMenuItemConnectionWhereArgs', [
         'language' => [
             'type' => 'String',


### PR DESCRIPTION
# Overview

Enables support for taxonomy term translations that return the correct _translated_ IDs and objects for terms in non-default locales.

<img width="982" alt="get-tags" src="https://user-images.githubusercontent.com/9002/116339814-f573c180-a792-11eb-975f-0c3fc97abf33.png">


## Details

Adds fields to Taxonomy types to be visible on the terms:

* `locale` - the locale of the current term
* `translations` - list of `TermTranslation` objects
* `translated` - list of the translated `Term` objects

Adds two hooks to resolve the issues with WPML term ID adjustment. Basically, WPML adjusts term ids for every request, shifting request terms to the "current language". The WPGraphQL requests don't typically use a current language and that's especially the case with Gatsby. We want to retrieve all of the terms at once and let Gatsby handle the language switching. These two hooks ensure that term IDs are untouched during GraphQL requests allowing retrieval of non-default locale terms. 

Adds a `slug` field to the term translation response to help in the situation where the same slug is used for terms in different locales. The example in the commit message shows what it would look like for the `tech` tag in two locales:

  * English
    - slug: `tech`
    - href: `https://.../tag/tech`

  * Spanish
    - slug: `tech`
    - href: `https://.../es/tag/tech-2`

Having the `slug` allows the client to do what it needs - in our case, it was building out tag pages with the correct tag in the route.

I've also included all of this context and more in the commit messages.