### PR TITLE
Removed the slug from URI of translated homepage

### DIFF
--- a/wp-graphql-wpml.php
+++ b/wp-graphql-wpml.php
@@ -182,16 +182,15 @@ function wpgraphqlwpml_add_post_type_fields(\WP_Post_Type $post_type_object)
                         \WP_Post::get_instance($post_id)
                     );
 
-                    // Check if:
-                    // - the current language is not the default language
-                    // - the homepage option is configured
-                    if($lang_code != $default_lang && $default_front_page_ID) {
+                    // Check if the homepage option is configured
+                    if($default_front_page_ID) {
+
+                        // Get the ID of the translated home page
                         $translated_front_pageID = apply_filters( 'wpml_object_id', $default_front_page_ID, 'page', FALSE, $lang_code );
 
                         if($post_id == $translated_front_pageID) {
-
-                            // Replace the URI
-                            $translation->uri = '/' . $lang_code;
+                            $new_uri = $lang_code == $default_lang ? '/' : '/' . $lang_code;
+                            $translation->uri = $new_uri;
                         }
                     }
 


### PR DESCRIPTION
### Overview
URI of translated page on front should not contain the slug
Details of the problem described in [Issue#19](https://github.com/rburgst/wp-graphql-wpml/issues/19)

![Screenshot from 2021-11-16 22-21-44](https://user-images.githubusercontent.com/8714097/142061350-61a9b319-1c96-4195-8ad8-b3406d3de3e4.png)

### Result
![Screenshot from 2021-11-16 22-21-53](https://user-images.githubusercontent.com/8714097/142061374-c853726f-d033-4c70-95cd-524e6c3ad229.png)


