### PR TITLE
Adds the language filtering option on taxonomy to post types connections

### DIFF
--- a/wp-graphql-wpml.php
+++ b/wp-graphql-wpml.php
@@ -456,6 +456,8 @@ function wpgraphqlwpml_action_graphql_register_language_where_filters()
         'RootQueryToPageConnectionWhereArgs',
         'RootQueryToCategoryConnectionWhereArgs',
         'RootQueryToCommentConnectionWhereArgs',
+        'CategoryToPostConnectionWhereArgs',
+        'PostToCategoryConnectionWhereArgs',
     ];
     
     $language_field_params = [
@@ -485,6 +487,19 @@ function wpgraphqlwpml_action_graphql_register_language_where_filters()
     //Add the custom taxonomies to the connections that require the language filter option
     foreach ($gql_valid_taxonomies as $custom_taxonomy) {
         $connections_where_name[] = 'RootQueryTo' . ucwords($custom_taxonomy->graphql_single_name) . 'ConnectionWhereArgs';
+        
+        if($custom_taxonomy->object_type){
+            //Add the language filter on the custom relations between taxonomies and post types
+            foreach ($custom_taxonomy->object_type as $post_type_name) {
+                if(isset($gql_valid_custom_post_types[$post_type_name])){
+                    $linked_post_type = $gql_valid_custom_post_types[$post_type_name];
+                    //Adds the taxonomy to custom post type connection
+                    $connections_where_name[] = ucwords($custom_taxonomy->graphql_single_name) . 'To' . ucwords($linked_post_type->graphql_single_name) . 'ConnectionWhereArgs';
+                    //Adds the custom post type to taxonomy connection (reverse)
+                    $connections_where_name[] = ucwords($linked_post_type->graphql_single_name) . 'To' . ucwords($custom_taxonomy->graphql_single_name) . 'ConnectionWhereArgs';
+                }
+            }
+        }
     }
 
     foreach ($connections_where_name as $connection) {


### PR DESCRIPTION
Fixes the issue where language filtering did not work on relationships between taxonomies and post types.

For example, the following query would return the posts associated to each category in the default language (english in my case), even if the categories are in french:
```
categories(where: {wpmlLanguage: "fr"}) {
  nodes {
    id
    name
    posts {
      nodes {
        title
      }
    }
  }
}
```
I expected to received the linked posts in the same language as my category.

My fix allows us to add the same wpmlLanguage filter on the child queries which will return the posts in the same language as the category:
```
categories(where: {wpmlLanguage: "fr"}) {
  nodes {
    id
    name
    posts(where: {wpmlLanguage: "fr"}) {
      nodes {
        title
      }
    }
  }
}
```

This fix works for the relationship between posts and categories, but il also works with any relationships between custom taxonomies and custom post types.

In an ideal world, we would not have to do this, but this is the fix I came up with. Feel free to do what you want with it.