### PR TITLE
Add a language filter for ACF options pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# JetBrains IDE files
+.idea/

--- a/acf-compatibility.php
+++ b/acf-compatibility.php
@@ -1,0 +1,61 @@
+<?php
+
+use WPGraphQL\Registry\TypeRegistry;
+use WPGraphQL\Utils\Utils;
+
+/**
+ * Registers a new "wpmlLanguage" input field on ACF options pages queries, and
+ * uses translated options page content based on the language code supplied
+ * @throws Exception
+ */
+function wpgraphqlwpml_action_add_options_pages_language_filter(TypeRegistry $type_registry)
+{
+    foreach (acf_get_options_pages() as $options_page) {
+        // Check if the option page should be shown in GraphQL schema
+        if (!isset($options_page['show_in_graphql']) || false === (bool)$options_page['show_in_graphql']) {
+            continue;
+        }
+        $type_name = Utils::format_type_name($options_page['graphql_field_name'] ?? $options_page['menu_slug']);
+        // Register new options page field with the wpmlLanguage argument
+        $options_page['type'] = 'options_page';
+        $type_registry->register_field(
+            'RootQuery',
+            Utils::format_field_name($type_name),
+            [
+                'type' => $type_name,
+                'args' => [
+                    'wpmlLanguage' => [
+                        'type' => 'String',
+                        'description' => 'Filter by WPML language code',
+                    ],
+                ],
+                'description' => sprintf(__('%s options.', 'wp-graphql-acf'), $options_page['page_title']),
+                'resolve' => function ($unused, $args) use ($options_page) {
+                    // If the wpmlLanguage argument exists in the arguments
+                    if (isset($args['wpmlLanguage'])) {
+                        $lang = $args['wpmlLanguage'];
+                        global $sitepress;
+                        // If WPML is installed
+                        if ($sitepress) {
+                            // Switch the current locale WPML
+                            $sitepress->switch_lang($lang);
+                            // Override ACF language explicitly, otherwise the output language doesn't change
+                            acf_update_setting('current_language', $lang);
+                        }
+                    }
+                    return !empty($options_page) ? $options_page : null;
+                }
+            ]
+        );
+    }
+}
+
+function wpgraphqlwpml_init_acf()
+{
+    add_action(
+        'graphql_register_types',
+        'wpgraphqlwpml_action_add_options_pages_language_filter',
+        10,
+        1
+    );
+}

--- a/wp-graphql-wpml.php
+++ b/wp-graphql-wpml.php
@@ -787,9 +787,11 @@ function wpgraphqlwpml_action_init() {
         2
     );
 
-    // Load ACF compatibility file and initialize
-    require_once 'acf-compatibility.php';
-    wpgraphqlwpml_init_acf();
+    // Load ACF compatibility (for options pages)
+    if (class_exists('ACF')) {
+        require_once 'acf-compatibility.php';
+        wpgraphqlwpml_init_acf();
+    }
 }
 
 add_action('graphql_init', 'wpgraphqlwpml_action_init');

--- a/wp-graphql-wpml.php
+++ b/wp-graphql-wpml.php
@@ -3,7 +3,6 @@
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
 use WPGraphQL\Model\Menu;
 use WPGraphQL\Model\Post;
-use WPGraphQL\Utils\Utils;
 
 /**
  * Plugin Name: WPGraphQL WPML
@@ -468,42 +467,6 @@ function wpgraphqlwpml_action_graphql_register_language_where_filters() {
     }
 }
 
-/**
- * Registers a new "wpmlLanguage" input field on ACF options pages queries
- * @throws Exception
- */
-function wpgraphqlwpml_action_add_options_pages_language_filter() {
-    foreach (acf_get_options_pages() as $options_page) {
-        // Check if the option page should be shown in GraphQL schema
-        if (!isset($options_page['show_in_graphql']) || false === (bool)$options_page['show_in_graphql']) {
-            continue;
-        }
-        // TODO: Figure out how to re-register field or add arguments to field, without removing children
-        $type_name = Utils::format_type_name($options_page['graphql_field_name'] ?? $options_page['menu_slug']);
-        $field_name = Utils::format_field_name($options_page['graphql_field_name'] ?? $options_page['menu_slug']);
-        // Remove existing options page field
-        deregister_graphql_field('RootQuery', $field_name);
-        // Register new options page field with the wpmlLanguage argument
-        register_graphql_field(
-            'RootQuery',
-            $field_name,
-            [
-                'type' => $type_name,
-                'args' => [
-                    'wpmlLanguage' => [
-                        'type' => 'String',
-                        'description' => 'Filter by WPML language code',
-                    ],
-                ],
-                'description' => sprintf(__('%s options.', 'wp-graphql-acf'), $options_page['page_title']),
-                'resolve' => function () use ($options_page) {
-                    return !empty($options_page) ? $options_page : null;
-                }
-            ]
-        );
-    }
-}
-
 function wpgraphqlwpml_theme_mod_nav_menu_locations(array $args): array {
     foreach ($args as $menu_name => $menu_term_id) {
         $translated = get_term($menu_term_id);
@@ -783,13 +746,6 @@ function wpgraphqlwpml_action_init() {
     );
 
     add_filter(
-        'graphql_register_types',
-        'wpgraphqlwpml_action_add_options_pages_language_filter',
-        10,
-        0
-    );
-
-    add_filter(
         'graphql_connection_should_execute',
         'wpgraphqlwpml_filter_graphql_connection_should_execute',
         10,
@@ -830,6 +786,10 @@ function wpgraphqlwpml_action_init() {
         10,
         2
     );
+
+    // Load ACF compatibility file and initialize
+    require_once 'acf-compatibility.php';
+    wpgraphqlwpml_init_acf();
 }
 
 add_action('graphql_init', 'wpgraphqlwpml_action_init');

--- a/wp-graphql-wpml.php
+++ b/wp-graphql-wpml.php
@@ -1,6 +1,9 @@
 <?php
 
 use WPGraphQL\Data\Connection\AbstractConnectionResolver;
+use WPGraphQL\Model\Menu;
+use WPGraphQL\Model\Post;
+use WPGraphQL\Utils\Utils;
 
 /**
  * Plugin Name: WPGraphQL WPML
@@ -21,8 +24,7 @@ use WPGraphQL\Data\Connection\AbstractConnectionResolver;
  */
 
 
-function wpgraphqlwpml_is_graphql_request()
-{
+function wpgraphqlwpml_is_graphql_request() {
     // Detect WPGraphQL activation by checking if the main class is defined
     if (!class_exists('WPGraphQL')) {
         return false;
@@ -32,21 +34,19 @@ function wpgraphqlwpml_is_graphql_request()
 }
 
 
-function wpgraphqlwpml_disable_wpml($query_args, $source, $args, $context, $info)
-{
+function wpgraphqlwpml_disable_wpml($query_args) {
     $query_args['suppress_wpml_where_and_join_filter'] = true;
     return $query_args;
 }
-add_filter('graphql_post_object_connection_query_args', 'wpgraphqlwpml_disable_wpml', 100, 5);
+add_filter('graphql_post_object_connection_query_args', 'wpgraphqlwpml_disable_wpml', 100, 1);
 
-function wpgraphqlwpml_handle_language_filter_request($query_args, $source, $args, $context, $info)
-{
+function wpgraphqlwpml_handle_language_filter_request($query_args, $source, $args) {
     $lang = $args['where']['wpmlLanguage'];
     //If the wpmlLanguage argument exists in the WHERE parameters
-    if(isset($lang)){
+    if (isset($lang)) {
         global $sitepress;
         //If WPML is installed
-        if($sitepress){
+        if ($sitepress) {
             //Switch the current locale
             $sitepress->switch_lang($lang);
             //Remove the argument added earlier that removes all language filtering
@@ -54,14 +54,13 @@ function wpgraphqlwpml_handle_language_filter_request($query_args, $source, $arg
         }
     }
 
-  return $query_args;
+    return $query_args;
 }
-add_filter('graphql_post_object_connection_query_args', 'wpgraphqlwpml_handle_language_filter_request', 110, 5);
-add_filter('graphql_term_object_connection_query_args', 'wpgraphqlwpml_handle_language_filter_request', 110, 5);
-add_filter('graphql_comment_object_connection_query_args', 'wpgraphqlwpml_handle_language_filter_request', 110, 5);
+add_filter('graphql_post_object_connection_query_args', 'wpgraphqlwpml_handle_language_filter_request', 110, 3);
+add_filter('graphql_term_object_connection_query_args', 'wpgraphqlwpml_handle_language_filter_request', 110, 3);
+add_filter('graphql_comment_object_connection_query_args', 'wpgraphqlwpml_handle_language_filter_request', 110, 3);
 
-function wpgraphqlwpml_add_post_type_fields(\WP_Post_Type $post_type_object)
-{
+function wpgraphqlwpml_add_post_type_fields(WP_Post_Type $post_type_object) {
     $type = ucfirst($post_type_object->graphql_single_name);
     register_graphql_field(
         $post_type_object->graphql_single_name,
@@ -69,12 +68,7 @@ function wpgraphqlwpml_add_post_type_fields(\WP_Post_Type $post_type_object)
         [
             'type' => 'Locale',
             'description' => __('WPML translation link', 'wp-graphql-wpml'),
-            'resolve' => function (
-                \WPGraphQL\Model\Post $post,
-                $args,
-                $context,
-                $info
-            ) {
+            'resolve' => function (Post $post, $args, $context, $info) {
                 $fields = $info->getFieldSelection();
                 $language = [
                     'id' => null,
@@ -104,12 +98,7 @@ function wpgraphqlwpml_add_post_type_fields(\WP_Post_Type $post_type_object)
         [
             'type' => 'String',
             'description' => __('WPML localized url of the page/post', 'wp-graphql-wpml'),
-            'resolve' => function (
-                \WPGraphQL\Model\Post $post,
-                $args,
-                $context,
-                $info
-            ) {
+            'resolve' => function (Post $post) {
                 global $sitepress;
 
                 $post_id = $post->ID;
@@ -123,9 +112,7 @@ function wpgraphqlwpml_add_post_type_fields(\WP_Post_Type $post_type_object)
                     }
                 }
 
-                list($thisPost, $translationUrl) = graphql_wpml_get_translation_url($post_id, $post_language);
-
-                return $translationUrl;
+                return graphql_wpml_get_translation_url($post_id, $post_language)[1];
             },
         ]
     );
@@ -135,12 +122,7 @@ function wpgraphqlwpml_add_post_type_fields(\WP_Post_Type $post_type_object)
         [
             'type' => ['list_of' => 'Translation'],
             'description' => __('WPML translations', 'wpnext'),
-            'resolve' => function (
-                \WPGraphQL\Model\Post $post,
-                $args,
-                $context,
-                $info
-            ) {
+            'resolve' => function (Post $post) {
                 global $sitepress;
                 $translations = [];
 
@@ -167,12 +149,7 @@ function wpgraphqlwpml_add_post_type_fields(\WP_Post_Type $post_type_object)
         [
             'type' => ['list_of' => $type],
             'description' => __('WPML translated versions of the same post', 'wpnext'),
-            'resolve' => function (
-                \WPGraphQL\Model\Post $post,
-                $args,
-                $context,
-                $info
-            ) {
+            'resolve' => function (Post $post, $args, $context, $info) {
                 global $sitepress;
                 global $wpdb;
 
@@ -198,8 +175,8 @@ function wpgraphqlwpml_add_post_type_fields(\WP_Post_Type $post_type_object)
 
                     if ($post_id === null || $post_id == $orig_post_id) continue;
 
-                    $translation = new \WPGraphQL\Model\Post(
-                        \WP_Post::get_instance($post_id)
+                    $translation = new Post(
+                        WP_Post::get_instance($post_id)
                     );
 
                     // Check if the homepage option is configured
@@ -214,7 +191,7 @@ function wpgraphqlwpml_add_post_type_fields(\WP_Post_Type $post_type_object)
                         }
                     }
 
-                    array_push($translations, $translation);
+                    $translations[] = $translation;
                 }
 
                 return $translations;
@@ -228,8 +205,7 @@ function wpgraphqlwpml_add_post_type_fields(\WP_Post_Type $post_type_object)
  * @param $language
  * @return array
  */
-function graphql_wpml_get_translation_url(int $post_id, $language): array
-{
+function graphql_wpml_get_translation_url(int $post_id, $language): array {
     $thisPost = get_post($post_id);
     if (array_key_exists('url', $language)) {
         $baseUrl = apply_filters('WPML_filter_link', $language['url'], $language);
@@ -375,7 +351,7 @@ function wpgraphqlwpml_action_graphql_register_types()
                 'List available languages',
                 'wp-graphql-wpml'
             ),
-            'resolve' => function ($source, $args, $context, $info) {
+            'resolve' => function () {
                 $args = array('skip_missing' => 1);
                 $language_infos = apply_filters('wpml_active_languages', null, $args);
 
@@ -397,7 +373,7 @@ function wpgraphqlwpml_action_graphql_register_types()
                 'List available locales',
                 'wp-graphql-wpml'
             ),
-            'resolve' => function ($source, $args, $context, $info) {
+            'resolve' => function () {
                 $args = array('skip_missing' => 1);
                 $language_infos = apply_filters('wpml_active_languages', null, $args);
                 $locales = array_map(function ($lang) {
@@ -411,12 +387,7 @@ function wpgraphqlwpml_action_graphql_register_types()
         'language' => [
             'type' => 'String',
             'description' => 'the language of the menu',
-            'resolve' => function (
-                \WPGraphQL\Model\Menu $menu,
-                $args,
-                $context,
-                $info
-            ) {
+            'resolve' => function (Menu $menu) {
                 $menuId = $menu->fields['databaseId'];
                 // note that sometimes the fields are closures which have to be resolved before
                 // we can access the values
@@ -441,7 +412,7 @@ function wpgraphqlwpml_action_graphql_register_types()
             }
         ],
     ]);
-    foreach (\WPGraphQL::get_allowed_post_types() as $post_type) {
+    foreach (WPGraphQL::get_allowed_post_types() as $post_type) {
         wpgraphqlwpml_add_post_type_fields(get_post_type_object($post_type));
     }
 }
@@ -449,15 +420,14 @@ function wpgraphqlwpml_action_graphql_register_types()
 /**
  * Registers a new "wpmlLanguage" where clause in specific post types (Pages, Posts, Categories, Comments, any custom post type and any custom taxonomy)
  */
-function wpgraphqlwpml_action_graphql_register_language_where_filters()
-{
+function wpgraphqlwpml_action_graphql_register_language_where_filters() {
     $connections_where_name = [
         'RootQueryToPostConnectionWhereArgs',
         'RootQueryToPageConnectionWhereArgs',
         'RootQueryToCategoryConnectionWhereArgs',
         'RootQueryToCommentConnectionWhereArgs',
     ];
-    
+
     $language_field_params = [
         'wpmlLanguage' => [
             'type' => 'String',
@@ -467,13 +437,13 @@ function wpgraphqlwpml_action_graphql_register_language_where_filters()
 
     //Get all new custom post types that are available in the GraphQL schema
     $gql_valid_custom_post_types = get_post_types([
-        'show_in_graphql' => true, 
+        'show_in_graphql' => true,
         '_builtin' => false
     ], 'objects');
 
     //Get all new taxonomies post types that are available in the GraphQL schema
     $gql_valid_taxonomies = get_taxonomies([
-        'show_in_graphql' => true, 
+        'show_in_graphql' => true,
         '_builtin' => false
     ], 'objects');
 
@@ -481,7 +451,7 @@ function wpgraphqlwpml_action_graphql_register_language_where_filters()
     foreach ($gql_valid_custom_post_types as $custom_post_type) {
         $connections_where_name[] = 'RootQueryTo' . ucwords($custom_post_type->graphql_single_name) . 'ConnectionWhereArgs';
     }
-    
+
     //Add the custom taxonomies to the connections that require the language filter option
     foreach ($gql_valid_taxonomies as $custom_taxonomy) {
         $connections_where_name[] = 'RootQueryTo' . ucwords($custom_taxonomy->graphql_single_name) . 'ConnectionWhereArgs';
@@ -492,8 +462,7 @@ function wpgraphqlwpml_action_graphql_register_language_where_filters()
     }
 }
 
-function wpgraphqlwpml__theme_mod_nav_menu_locations(array $args)
-{
+function wpgraphqlwpml_theme_mod_nav_menu_locations(array $args) {
     foreach ($args as $menu_name => $menu_term_id) {
         $translated = get_term($menu_term_id);
         $args[$menu_name] = $translated->term_id;
@@ -501,8 +470,7 @@ function wpgraphqlwpml__theme_mod_nav_menu_locations(array $args)
     return $args;
 }
 
-function resolve_menu_location_filter($location_filter, $language_filter)
-{
+function resolve_menu_location_filter($location_filter, $language_filter) {
     global $sitepress;
 
     // we have the list of location ids in our `include` list, now we somehow need to figure out
@@ -545,8 +513,7 @@ function resolve_menu_location_filter($location_filter, $language_filter)
 
 $wpgraphqlwpml_url_filter_off = false;
 
-function wpgraphqlwpml__filter_graphql_connection_query_args(array $args = null)
-{
+function wpgraphqlwpml_filter_graphql_connection_query_args(array $args = null) {
     global $sitepress;
 
     if (!$args) {
@@ -616,10 +583,10 @@ function wpgraphqlwpml__filter_graphql_connection_query_args(array $args = null)
     if ($cur_lang !== $target_lang) {
         $sitepress->switch_lang($target_lang);
 
-        if (!has_filter('theme_mod_nav_menu_locations', 'wpgraphqlwpml__theme_mod_nav_menu_locations')) {
-            add_filter('theme_mod_nav_menu_locations', 'wpgraphqlwpml__theme_mod_nav_menu_locations');
+        if (!has_filter('theme_mod_nav_menu_locations', 'wpgraphqlwpml_theme_mod_nav_menu_locations')) {
+            add_filter('theme_mod_nav_menu_locations', 'wpgraphqlwpml_theme_mod_nav_menu_locations');
         }
-        //        $args['where']['location'] = wpgraphqlwpml__translate_menu_location(
+        //        $args['where']['location'] = wpgraphqlwpml_translate_menu_location(
         //            $args['where']['location'],
         //            $target_lang
         //        );
@@ -632,11 +599,9 @@ function wpgraphqlwpml__filter_graphql_connection_query_args(array $args = null)
 
 $wpgraphqlwpml_prev_language = null;
 
-function wpgraphqlwpml__filter_graphql_connection_should_execute(bool $should_execute, AbstractConnectionResolver $resolver)
-{
+function wpgraphqlwpml_filter_graphql_connection_should_execute(bool $should_execute, AbstractConnectionResolver $resolver) {
     global $sitepress;
     global $wpgraphqlwpml_prev_language;
-
 
     $fieldName = $resolver->getInfo()->fieldName;
     if ($fieldName === 'menuItems') {
@@ -667,17 +632,7 @@ function wpgraphqlwpml__filter_graphql_connection_should_execute(bool $should_ex
     return $should_execute;
 }
 
-function wpgraphqlpwml__filter_graphql_return_field_from_model(
-    $field,
-    $key,
-    $model_name,
-    $data,
-    $visibility,
-    $owner,
-    $current_user
-) {
-    global $sitepress;
-
+function wpgraphqlwpml_filter_graphql_return_field_from_model($field, $key, $model_name, $data) {
     if ($model_name === 'MenuObject' && $key === 'locations' && $field === null) {
         // this is a case where we have a menu item in a different language and no location
         // matches since locations point to the default menu id, therefore, we need to re-load
@@ -707,8 +662,7 @@ function wpgraphqlwpml__filter_graphql_connection_query(mixed $query, AbstractCo
     return $query;
 }
 
-function wpgraphqlwpml__filter_graphql_pre_model_data_is_private($unused, $model_name, $data, $visibility, $owner, $current_user)
-{
+function wpgraphqlwpml_filter_graphql_pre_model_data_is_private($unused, $model_name) {
     // we need to avoid not being able to see menu items, depending on your settings and auth
     // it often is the case that the graphql user does not seem to have permissions to read
     // menus (not sure why this is not the case for pages, etc.)
@@ -718,8 +672,7 @@ function wpgraphqlwpml__filter_graphql_pre_model_data_is_private($unused, $model
     return null;
 }
 
-function wpgraphqlwpml__filter_graphql_connection_ids(array $ids, AbstractConnectionResolver $resolver)
-{
+function wpgraphqlwpml_filter_graphql_connection_ids(array $ids, AbstractConnectionResolver $resolver) {
     global $wpgraphqlwpml_prev_language;
     global $wpgraphqlwpml_url_filter_off;
 
@@ -769,8 +722,7 @@ function wpgraphqlwpml__filter_graphql_connection_ids(array $ids, AbstractConnec
  * `switch_lang` method allows for setting toe current language to
  * 'all' - once set this way, taxonomies are not filtered by language.
  */
-function wpgraphqlwpml__switch_language_to_all_for_query(array $args)
-{
+function wpgraphqlwpml_switch_language_to_all_for_query(array $args) {
     global $sitepress;
 
     // Set lang to 'all' when querying for built-in taxonomies
@@ -784,8 +736,7 @@ function wpgraphqlwpml__switch_language_to_all_for_query(array $args)
     return $args;
 }
 
-function wpgraphqlwpml_action_init()
-{
+function wpgraphqlwpml_action_init() {
     if (!wpgraphqlwpml_is_graphql_request()) {
         return;
     }
@@ -811,34 +762,34 @@ function wpgraphqlwpml_action_init()
 
     add_filter(
         'graphql_connection_should_execute',
-        'wpgraphqlwpml__filter_graphql_connection_should_execute',
+        'wpgraphqlwpml_filter_graphql_connection_should_execute',
         10,
         2
     );
 
     add_filter(
         'graphql_connection_ids',
-        'wpgraphqlwpml__filter_graphql_connection_ids',
+        'wpgraphqlwpml_filter_graphql_connection_ids',
         10,
         2
     );
 
     add_filter(
         'graphql_pre_model_data_is_private',
-        'wpgraphqlwpml__filter_graphql_pre_model_data_is_private',
+        'wpgraphqlwpml_filter_graphql_pre_model_data_is_private',
         10,
-        6
+        2
     );
     add_filter(
         'graphql_return_field_from_model',
-        'wpgraphqlpwml__filter_graphql_return_field_from_model',
+        'wpgraphqlwpml_filter_graphql_return_field_from_model',
         10,
-        7
+        4
     );
 
     add_filter(
         'graphql_connection_query_args',
-        'wpgraphqlwpml__filter_graphql_connection_query_args',
+        'wpgraphqlwpml_filter_graphql_connection_query_args',
         10,
         2
     );
@@ -846,7 +797,7 @@ function wpgraphqlwpml_action_init()
     // Add filter to adjust WPML language for certain queries
     add_filter(
         'graphql_connection_query_args',
-        'wpgraphqlwpml__switch_language_to_all_for_query',
+        'wpgraphqlwpml_switch_language_to_all_for_query',
         10,
         2
     );


### PR DESCRIPTION
The main addition of this PR is the addition of a `wpmlLanguage` argument on ACF options page fields, which controls the language of the query output. By default, ACF options pages only output the default site language on WPGraphQL. This argument allows the user to supply a language code (e.g. "en", or "nl"), very similar to PR https://github.com/rburgst/wp-graphql-wpml/pull/32.

I added a gitignore file to ensure no unnecessary files are added to the repository.

I also took some time to consistently reformat the plugin's code, add `use` statements to replace FQCNs, remove unused function arguments, replace deprecated function calls, and remove some duplicate and unused code. The exact changes can be found in the first few commits.

The (WIP) commit is an intermediate commit where I failed to get it fully working, you can essentially ignore that, as I moved the code into a separate file in the last commit, while also solving the problem and getting it to function correctly.